### PR TITLE
chore: jx-go-quickstart to 0.0.3

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -10,3 +10,6 @@ dependencies:
 - name: go-example-cjxd
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.5
+- name: jx-go-quickstart
+  repository: http://jenkins-x-chartmuseum:8080
+  version: 0.0.3


### PR DESCRIPTION
chore: Promote jx-go-quickstart to version 0.0.3